### PR TITLE
Multiple bugfixes, including match against self

### DIFF
--- a/comparison.py
+++ b/comparison.py
@@ -8,7 +8,7 @@ class ComparisonResult(Enum):
     CONTENT_PATH_DUP = ("content", "path")  # Same content and path, different name
     NAME_DUP = ("name",)  # Same name, different content and path
     CONTENT_DUP = ("content",)  # Same content, different name and path
-    UNQIUE = ()  # No shared traits
+    UNIQUE = ()  # No shared traits
 
 
 class Comparison:

--- a/dir_index.py
+++ b/dir_index.py
@@ -17,15 +17,16 @@ class DirIndex:
         self.name = name
         self.logger = logging.getLogger(__name__)
 
-        # Dicts for indexing
+        # Common trait indexes
         self.all_files: List[File] = []
         self.name_index: Dict[str : List[File]] = name_index or defaultdict(list)
         self.path_index: Dict[str : List[File]] = path_index or defaultdict(list)
         self.size_index: Dict[int : List[File]] = size_index or defaultdict(list)
 
-        # Dicts for comparisons
         # Cache for already seen comparisons
         self.comparison_cache: Dict[Tuple(File, File) : Comparison] = defaultdict(list)
+
+        # Comparison indexes
         self.matches = ComparisonIndex("MATCH", ComparisonResult.MATCH)
         self.diffs = ComparisonIndex("DIFF", ComparisonResult.DIFF)
         self.content_name_dups = ComparisonIndex(
@@ -67,13 +68,13 @@ class DirIndex:
             for key, file_list in index.items():
                 msg.append(f"{key}:\n")
                 for file in file_list:
-                    msg.append(str(file))
+                    msg.append(f"\t{str(file)}\n\n")
 
             # Write the string to the file
             utils.write_to_file(
                 filename=name,
                 output_dir=output_dir / name,
-                msg=msg,
+                msg="".join(msg),
                 is_timestamped=True,
             )
 
@@ -96,7 +97,7 @@ class DirIndex:
             filename="UNIQUE",
             output_dir=output_dir / "UNIQUE",
             msg=str("\n".join(map(str, self.unique))),
-            s_timestamped=True,
+            is_timestamped=True,
         )
 
     # Add all files in the given directory to this index
@@ -125,55 +126,62 @@ class DirIndex:
     #   Content-Path-Dup, Content-Dup
     # If no other comparison is found yet, then the file is unique
     def find_compare(self):
-        def compare_files(file_a: File, file_b: File):
-            """Compares two files and caches the result. Returns True if a meaningful comparison was added."""
-            if self.comparison_cache[(file_a, file_b)]:
-                return False
-
-            comparison: Comparison = file_a.compare_to(file_b)
-            self.comparison_cache[(file_a, file_b)] = comparison
-            match comparison.type:
-                case ComparisonResult.MATCH:
-                    self.matches.add_comparison(comparison)
-                case ComparisonResult.DIFF:
-                    self.diffs.add_comparison(comparison)
-                case ComparisonResult.CONTENT_NAME_DUP:
-                    self.content_name_dups.add_comparison(comparison)
-                case ComparisonResult.CONTENT_PATH_DUP:
-                    self.content_path_dups.add_comparison(comparison)
-                case ComparisonResult.NAME_DUP:
-                    self.name_dups.add_comparison(comparison)
-                case ComparisonResult.CONTENT_DUP:
-                    self.content_dups.add_comparison(comparison)
-                case _:
-                    self.logger.info(f"NO RELATION: {file_a.name}, {file_b.name}")
-                    return False
-            return True
-
-        def compare_group(file_list):
-            """Compares all unique pairs in a group. Returns True if any comparison was found."""
-            found = False
-            if len(file_list) > 1:
-                for i, file_a in enumerate(same_name_files):
-                    for file_b in file_list[i + 1 :]:
-                        if compare_files(file_a, file_b):
-                            found = True
-            return found
-
         for file in self.all_files:
             file: File
-            self.logger.info(f"Analyzing {file}")
+            self.logger.info(f"\nAnalyzing {file}")
 
             # Test against other files with the same name
             self.logger.info("Comparing against same name:")
             same_name_files = self.name_index[file.name]
-            found_name_compare = compare_group(same_name_files)
+            found_name_compare = self._compare_group(same_name_files)
+            if not found_name_compare:
+                self.logger.info("No same name matches found")
 
             # Test against other files with the same size
             self.logger.info("Comparing against same size:")
             same_size_files = self.size_index[file.size]
-            found_size_compare = compare_group(same_size_files)
+            found_size_compare = self._compare_group(same_size_files)
+            if not found_size_compare:
+                self.logger.info("No same size matches found")
 
             if not found_name_compare and not found_size_compare:
                 self.logger.info("Unique file")
                 self.unique.append(file)
+
+    def _compare_group(self, file_list):
+        """Compares all unique pairs in a group. Returns True if any comparison was found within the group."""
+        found = False
+        if len(file_list) > 1:
+            for i, file_a in enumerate(file_list):
+                for file_b in file_list[i + 1 :]:
+                    if self._compare_files(file_a, file_b):
+                        found = True
+        return found
+
+    def _compare_files(self, file_a: File, file_b: File):
+        """Compares two files and caches the result. Returns True if a meaningful comparison was added."""
+        if (
+            self.comparison_cache[(file_a, file_b)]
+            or self.comparison_cache[(file_b, file_a)]
+        ):
+            return False
+
+        comparison: Comparison = file_a.compare_to(file_b)
+        self.comparison_cache[(file_a, file_b)] = comparison
+        match comparison.type:
+            case ComparisonResult.MATCH:
+                self.matches.add_comparison(comparison)
+            case ComparisonResult.DIFF:
+                self.diffs.add_comparison(comparison)
+            case ComparisonResult.CONTENT_NAME_DUP:
+                self.content_name_dups.add_comparison(comparison)
+            case ComparisonResult.CONTENT_PATH_DUP:
+                self.content_path_dups.add_comparison(comparison)
+            case ComparisonResult.NAME_DUP:
+                self.name_dups.add_comparison(comparison)
+            case ComparisonResult.CONTENT_DUP:
+                self.content_dups.add_comparison(comparison)
+            case _:
+                self.logger.info(f"NO RELATION: {file_a.name}, {file_b.name}")
+                return False
+        return True

--- a/file.py
+++ b/file.py
@@ -21,20 +21,23 @@ class File:
         )
 
     def __str__(self):
-        msg = (
-            f"File: {self.name}\n"
-            f"\tRel_Path: {self.rel_path}\n"
-            f"\tAbs_Path: {self.abs_path}\n"
-            f"\tSize: {self.size}\n"
-        )
+        msg = [
+            f"File: {self.name}",
+            f"\tRel_Path: {self.rel_path}",
+            f"\tAbs_Path: {self.abs_path}",
+            f"\tSize: {self.size}",
+        ]
         if self.quick_hash is not None:
-            msg += f"\tQuick Hash: {self.quick_hash}\n"
+            msg.append(f"\tQuick Hash: {self.quick_hash}")
         if self.full_hash is not None:
-            msg += f"\tFull Hash: {self.full_hash}\n"
+            msg.append(f"\tFull Hash: {self.full_hash}")
 
-        return msg
+        return "\n".join(msg)
 
     def compare_to(self, other: "File") -> Comparison:
+        if self is other:
+            raise ValueError(f"Attempted to compare file {repr(self)} to itself")
+
         # Compare traits
         same_name = self.name == other.name
         same_path = self.rel_path == other.rel_path

--- a/main.py
+++ b/main.py
@@ -53,8 +53,10 @@ def build_index():
     dirA = DirIndex("dirA")
     dirA.index_dir(config.PATH_A)
     dirA.index_dir(config.PATH_B)
+    dirA.print_index_to_file(config.OUTPUT_DIR_PATH)
+
     dirA.find_compare()
-    dirA.print_to_file(config.OUTPUT_DIR_PATH)
+    dirA.print_comparison_to_file(config.OUTPUT_DIR_PATH)
     """
     compare = dirA.compare_to(dirB)
     write_compare_to_file(compare)


### PR DESCRIPTION
The nested method inside find_compare was pulling from same_name_files rather than file_list. This means that name_index was compared twice and size_index was not compared at all. To prevent this in the future, added an exception for when a file is compared to itself and to check the comparison cache for both (file_a, file_b) and (file_b, file_a).

Changed how indexes and files are printed. Also made indexes always print inside main.

Fixed a spelling error with "unique" in comparison.